### PR TITLE
[Feature] Support M218 'HOTENDS_OFFSETS' backup (Need Help)

### DIFF
--- a/octoprint_eeprom_marlin/data.py
+++ b/octoprint_eeprom_marlin/data.py
@@ -100,6 +100,17 @@ ALL_DATA_STRUCTURE = {
         "name": "Home Offset",
         "link": "https://marlinfw.org/docs/gcode/M206.html",
     },
+    "hotends_offset": {
+        "command": "M218",
+        "params": {
+            "X": {"type": "float2", "label": "X hotends offset", "units": "mm"},
+            "Y": {"type": "float2", "label": "Y hotends offset", "units": "mm"},
+            "Z": {"type": "float2", "label": "Z hotends offset", "units": "mm"},
+        },
+        "switches": ["T"],
+        "name": "Hotends Offset",
+        "link": "https://marlinfw.org/docs/gcode/M218.html",
+    },
     "endstop": {
         "command": "M666",
         "params": {

--- a/octoprint_eeprom_marlin/static/js/eeprom_marlin.js
+++ b/octoprint_eeprom_marlin/static/js/eeprom_marlin.js
@@ -93,6 +93,8 @@ $(function () {
 
       eeprom.home_offset = create_eeprom_observables(["X", "Y", "Z"]);
 
+      eeprom.hotends_offset = create_eeprom_observables(["X", "Y", "Z"], ["T"]);
+
       eeprom.hotend_pid = create_eeprom_observables(["P", "I", "D"], ["E"]);
 
       eeprom.hotend_mpc = create_eeprom_observables(

--- a/octoprint_eeprom_marlin/templates/sub/tab-content.jinja2
+++ b/octoprint_eeprom_marlin/templates/sub/tab-content.jinja2
@@ -57,6 +57,7 @@
 </div>
 <div id="eeprom_offset" class="tab-pane">
     {{ section("Home Offset", "home_offset") }}
+    {{ section("Hotends Offset", "hotends_offset") }}
     {{ section("Probe Offset", "probe_offset") }}
 </div>
 <div id="eeprom_pid" class="tab-pane">

--- a/octoprint_eeprom_marlin/templates/sub/tab-sidebar.jinja2
+++ b/octoprint_eeprom_marlin/templates/sub/tab-sidebar.jinja2
@@ -11,7 +11,7 @@
     <li data-bind="visible: eeprom.max_acceleration.visible() || eeprom.print_acceleration.visible()">
         <a data-toggle="tab" href="#eeprom_acceleration">Acceleration</a>
     </li>
-    <li data-bind="visible: eeprom.home_offset.visible() || eeprom.probe_offset.visible()">
+    <li data-bind="visible: eeprom.home_offset.visible() || eeprom.hotends_offset.visible() || eeprom.probe_offset.visible()">
         <a data-toggle="tab" href="#eeprom_offset">Offsets</a>
     </li>
     <li data-bind="visible: eeprom.bed_pid.visible() || eeprom.hotend_pid.visible()">


### PR DESCRIPTION
Adds M218 'HOTENDS_OFFSETS' backup.

BUT ! I have tweaked marlin to send all 'hotends_offset'  (T0 not sent)
M218 have permanent offset for T0 = 0,0,0. And the report doesn't send it.
I added the report of T0 and plugin works

HELP 
- If someone can tweak the parser in the code , to avoid skipping M218 READING 
Thks

notice: I can make it , but takes time to understand the code of the parser and afraid to code quickly something that will break elsewhere